### PR TITLE
Add JPA to example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <liberty.var.artifactId>${project.artifactId}</liberty.var.artifactId>
+        <!-- Derby library -->
+        <version.derby>10.14.2.0</version.derby>
+        <derby.path>${user.home}/.m2/repository/org/apache/derby/derby</derby.path>
+        <liberty.var.derby.lib>${derby.path}/${version.derby}/derby-${version.derby}.jar</liberty.var.derby.lib>
     </properties>
 
     <dependencies>
@@ -72,6 +76,13 @@
             <version>2.3.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- Derby from https://mvnrepository.com/artifact/org.apache.derby/derby -->
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${version.derby}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,19 +90,19 @@
         <plugins>
             <!-- Enable liberty-maven plugin -->
             <!-- tag::libertyMavenPlugin[] -->
-            <plugin>
-                <groupId>io.openliberty.tools</groupId>
-                <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.4</version>
-                <configuration>
-                    <runtimeArtifact>
-                        <groupId>io.openliberty.beta</groupId>
-                        <artifactId>openliberty-jakartaee9</artifactId>
-                        <version>21.0.0.2-beta</version>
-                        <type>zip</type>
-                    </runtimeArtifact>
-                </configuration>
-            </plugin>
+			<plugin>
+               <groupId>io.openliberty.tools</groupId>
+               <artifactId>liberty-maven-plugin</artifactId>
+               <version>3.3.4</version>
+               <configuration>
+                   <runtimeArtifact>
+                       <groupId>io.openliberty.beta</groupId>
+                       <artifactId>openliberty-jakartaee9</artifactId>
+                       <version>21.0.0.3-beta</version>
+                       <type>zip</type>
+                   </runtimeArtifact>
+               </configuration>
+           </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -108,6 +119,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-derby-dependency</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>derby</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}/liberty/wlp/usr/shared/resources/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/openliberty/sample/jakarta/beanval/Person.java
+++ b/src/main/java/io/openliberty/sample/jakarta/beanval/Person.java
@@ -1,5 +1,12 @@
 package io.openliberty.sample.jakarta.beanval;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.DecimalMax;
@@ -9,16 +16,34 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Positive;
 
+@Entity
+@Table(name = "Person")
+@NamedQuery(name="Person.findAll", query="Select p FROM Person p")
 public class Person {
 	
-	@Positive
-    private Integer studentId;
-	
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name="id")
+    private long id;
+    	
 	@NotNull
+    @Column(name="name")
 	private String name;
 
     @Positive
     private int age;
+
+    public long getId() {
+        return id;
+    }
+        
+    public String getName() {
+    	return this.name;
+    }
+
+    public int getAge() {
+    	return this.age;
+    }
 
 //    @AssertTrue
 //    private boolean isSubscribed;
@@ -32,12 +57,13 @@ public class Person {
 //    public static boolean isCat() {
 //        return false;
 //    }
-    
-    public String getName() {
-    	return this.name;
+
+
+    public Person() {
     }
-    
-    public Person(String name) {
+
+    public Person(String name, int age) {
     	this.name = name;
+        this.age = age;
     }
 }

--- a/src/main/java/io/openliberty/sample/jakarta/beanval/Students.java
+++ b/src/main/java/io/openliberty/sample/jakarta/beanval/Students.java
@@ -3,26 +3,59 @@ package io.openliberty.sample.jakarta.beanval;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.annotation.Resource;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.UserTransaction;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 
+@RequestScoped
 @Path("/Students")
 public class Students {
-	
-	public static List<Person> students = new ArrayList<Person>();
-	
+
+	@Resource
+	UserTransaction utx;
+
+	@PersistenceContext(name="jpa-unit")
+	EntityManager em;
+
+	public void createStudent(Person s) {
+		try {
+			utx.begin();
+			em.persist(s);
+			utx.commit();
+		} catch (Exception e) {
+            System.out.println("Exception in create: " + e.getMessage());
+        }
+	}
+
+	public List<Person> readAllStudents() {
+		return em.createNamedQuery("Person.findAll", Person.class).getResultList();
+	}
+
 	@GET
 	@Path("/list")
 	@Produces(MediaType.APPLICATION_JSON)
 	public List<Person> getStudents() {
-		return this.students;
+		List<Person> students = new ArrayList<Person>();
+		for (Person p: this.readAllStudents()) {
+			students.add(p);
+		}
+		return students;
 	}
 	
 	@POST
-	@Path("/create")
-	public void createStudent(String name) {
-		System.out.println("Creating student: " + name);
-		Person student = new Person(name);
-		this.students.add(student);
+	@Path("/{name}/{age}")
+	public void createNewStudent(@PathParam("name") String name, @PathParam("age") int age) {
+		System.out.println("Creating student: " + name + "; " + age);
+		try {
+			Person student = new Person(name, age);
+			this.createStudent(student);
+		} catch (Exception e) {
+			System.out.println("Could not create a new student " + e.getMessage());
+		}
+		
 	}
 }

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -7,4 +7,16 @@
 
     <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
 
+    <!-- Derby Library Configuration -->    
+    <library id="derbyJDBCLib">
+        <file name="${derby.lib}" />
+    </library>
+
+    <!-- Datasource Configuration -->
+    <!-- tag::data-source[] -->
+    <dataSource id="eventjpadatasource"
+                jndiName="jdbc/eventjpadatasource">
+        <jdbcDriver libraryRef="derbyJDBCLib" />
+        <properties.derby.embedded databaseName="EventDB" createDatabase="create"/>
+    </dataSource>
 </server>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+                            https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+        version="3.0">
+        <persistence-unit name="jpa-unit" transaction-type="JTA">
+            <jta-data-source>jdbc/eventjpadatasource</jta-data-source>
+            <properties>
+                <!-- tag::eclipse-link[] -->
+                    <property name="eclipselink.ddl-generation" value="create-tables"/>
+                    <property name="eclipselink.ddl-generation.output-mode" value="both" />
+                <!-- end::eclipse-link[] -->
+                </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
- Adds JPA to example
- Using Apache Derby for DB
- Person class is not a JPA entity with bean validation constraints

You can make a POST request like this:
`curl -X POST http://localhost:9080/Students/Bob/12`

You can test invalid constraints:
`curl -X POST http://localhost:9080/Students/Bob/-12`
Which will result in bean validation constraint error in the dev mode output:
```
Exception in create: One or more Bean Validation constraints were violated while executing Automatic Bean Validation on callback event: prePersist for class: io.openliberty.sample.jakarta.beanval.Person. Please refer to the embedded constraint violations for details.
```

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>